### PR TITLE
Ubuntu 10.10 when it is capitalized returns 

### DIFF
--- a/lib/badfruit.rb
+++ b/lib/badfruit.rb
@@ -1,5 +1,5 @@
 require 'httparty'
-require 'JSON'
+require 'json'
 require 'cgi'
 
 require File.join(File.expand_path(File.dirname(__FILE__)), 'badfruit', 'base')


### PR DESCRIPTION
`require': no such file to load -- JSON (LoadError)
/gems/badfruit-0.0.5/lib/badfruit.rb:2:in`<top (required)>'
