### PR TITLE
Move classes to the BadFruit module to avoid namespace collisions.

### DIFF
--- a/badfruit.gemspec
+++ b/badfruit.gemspec
@@ -1,0 +1,38 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name = "badfruit"
+  s.version = "1.1.2.1"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
+  s.authors = ["Brian Michel"]
+  s.date = "2012-04-21"
+  s.description = "Interface with the Rotten Tomatoes API"
+  s.email = "brian.michel@gmail.com"
+  s.extra_rdoc_files = ["LICENSE", "README.md", "lib/badfruit.rb", "lib/badfruit/Actors/actor.rb", "lib/badfruit/Lists/lists.rb", "lib/badfruit/Movies/movie.rb", "lib/badfruit/Movies/movies.rb", "lib/badfruit/Posters/posters.rb", "lib/badfruit/Reviews/review.rb", "lib/badfruit/Scores/scores.rb", "lib/badfruit/base.rb"]
+  s.files = ["LICENSE", "Manifest", "README.md", "Rakefile", "features/client_creation.feature", "features/client_query.feature", "features/client_reviews.feature", "features/step_definitions/step_definitions.rb", "lib/badfruit.rb", "lib/badfruit/Actors/actor.rb", "lib/badfruit/Lists/lists.rb", "lib/badfruit/Movies/movie.rb", "lib/badfruit/Movies/movies.rb", "lib/badfruit/Posters/posters.rb", "lib/badfruit/Reviews/review.rb", "lib/badfruit/Scores/scores.rb", "lib/badfruit/base.rb", "badfruit.gemspec"]
+  s.homepage = "http://www.github.com/brianmichel/badfruit"
+  s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Badfruit", "--main", "README.md"]
+  s.require_paths = ["lib"]
+  s.rubyforge_project = "badfruit"
+  s.rubygems_version = "1.8.22"
+  s.summary = "Interface with the Rotten Tomatoes API"
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 3
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<json>, [">= 0"])
+      s.add_runtime_dependency(%q<httparty>, [">= 0"])
+      s.add_development_dependency(%q<cucumber>, [">= 0"])
+    else
+      s.add_dependency(%q<json>, [">= 0"])
+      s.add_dependency(%q<httparty>, [">= 0"])
+      s.add_dependency(%q<cucumber>, [">= 0"])
+    end
+  else
+    s.add_dependency(%q<json>, [">= 0"])
+    s.add_dependency(%q<httparty>, [">= 0"])
+    s.add_dependency(%q<cucumber>, [">= 0"])
+  end
+end

--- a/lib/badfruit/Actors/actor.rb
+++ b/lib/badfruit/Actors/actor.rb
@@ -1,8 +1,10 @@
-class Actor
-  attr_accessor :name, :characters
-  
-  def initialize(actorHash)
-    @name = actorHash["name"]
-    @characters = actorHash["characters"]
+module BadFruit
+  class Actor
+    attr_accessor :name, :characters
+
+    def initialize(actorHash)
+      @name = actorHash["name"]
+      @characters = actorHash["characters"]
+    end
   end
 end

--- a/lib/badfruit/Reviews/review.rb
+++ b/lib/badfruit/Reviews/review.rb
@@ -1,11 +1,13 @@
-class Review
-  attr_accessor :critic, :date, :publication, :quote, :links
-  
-  def initialize(reviewHash)
-    @critic = reviewHash["critic"]
-    @date = reviewHash["date"]
-    @publication = reviewHash["publication"]
-    @quote = reviewHash["quote"]
-    @links = reviewHash["links"]
+module BadFruit
+  class Review
+    attr_accessor :critic, :date, :publication, :quote, :links
+
+    def initialize(reviewHash)
+      @critic = reviewHash["critic"]
+      @date = reviewHash["date"]
+      @publication = reviewHash["publication"]
+      @quote = reviewHash["quote"]
+      @links = reviewHash["links"]
+    end
   end
 end

--- a/lib/badfruit/Scores/scores.rb
+++ b/lib/badfruit/Scores/scores.rb
@@ -1,4 +1,5 @@
-class Scores
+module BadFruit
+  class Scores
   attr_reader :critics_score, :audience_score
   def initialize(scoreHash)
     @critics_score = scoreHash["critics_score"]
@@ -7,5 +8,6 @@ class Scores
   
   def average
     return ((@critics_score + @audience_score) / 2) #ultimate math skillz.
+  end
   end
 end


### PR DESCRIPTION
Hello,

I defined the Actor, Review, and Scores classes in the BadFruit module.  My rails project had already defined an Actor class and I was running into namespace problems where rails  would use BadFruit's Actor class instead of the Actor class I defined.

I also added the gemspec file to the git repo so that the rails bundler can install the gem from git.

Regards,