### PR TITLE
Fixes Movies#search_by_name when no results are found

### DIFF
--- a/lib/badfruit/Movies/movies.rb
+++ b/lib/badfruit/Movies/movies.rb
@@ -1,17 +1,23 @@
 module BadFruit
   class Movies
     MAX_PAGE_LIMIT = 50
-    
+
     def initialize(badfruit)
       @badfruit = badfruit
     end
-    
+
     #returns an array of movie objects from the given search result.
     def search_by_name(name, page_limit=1, page=1)
       if page_limit > 50
         page_limit = MAX_PAGE_LIMIT #current limitation of the rotten tomatos API
       end
-      return @badfruit.parse_movies_array(JSON.parse(@badfruit.search_movies(name, page_limit, page)))
+
+      results_json = @badfruit.search_movies(name, page_limit, page)
+      if results_json.nil?
+        return []
+      else
+        return @badfruit.parse_movies_array(JSON.parse(results_json))
+      end
     end
 
     # search by id


### PR DESCRIPTION
search_movies returns nil for no results. JSON#parse blows up when given a nil. This protects against that and returns an empty array for no results.