### PR TITLE
add workaround for getting directors

### DIFF
--- a/lib/badfruit.rb
+++ b/lib/badfruit.rb
@@ -10,6 +10,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'badfruit', 'Actors'
 require File.join(File.expand_path(File.dirname(__FILE__)), 'badfruit', 'Lists', 'lists')
 require File.join(File.expand_path(File.dirname(__FILE__)), 'badfruit', 'Posters', 'posters')
 require File.join(File.expand_path(File.dirname(__FILE__)), 'badfruit', 'Scores', 'scores')
+require File.join(File.expand_path(File.dirname(__FILE__)), 'badfruit', 'Directors', 'director')
 
 module BadFruit
   def self.new(apikey)

--- a/lib/badfruit/Directors/director.rb
+++ b/lib/badfruit/Directors/director.rb
@@ -1,7 +1,9 @@
-class Director
-  attr_accessor :name
-  
-  def initialize(directorHash)
-    @name = directorHash["name"]
+module BadFruit
+  class Director
+    attr_accessor :name
+    
+    def initialize(directorHash)
+      @name = directorHash["name"]
+    end
   end
 end

--- a/lib/badfruit/Directors/director.rb
+++ b/lib/badfruit/Directors/director.rb
@@ -1,0 +1,7 @@
+class Director
+  attr_accessor :name
+  
+  def initialize(directorHash)
+    @name = directorHash["name"]
+  end
+end

--- a/lib/badfruit/Movies/movie.rb
+++ b/lib/badfruit/Movies/movie.rb
@@ -26,6 +26,11 @@ module BadFruit
       return @badfruit.parse_actors_array(JSON.parse(@badfruit.get_movie_info(@id, "cast")))
     end
 
+    # Returns director, since RottenTomatoes API is broken (abridged_director doesn't show up in search_by_name results for movies.)
+    def director
+      return Director.new(JSON.parse(@badfruit.get_movie_info(@id, "details"))["abridged_directors"][0])
+    end
+
     #returns an array of Review objects
     def reviews
       data = JSON.parse(@badfruit.get_movie_info(@id, "reviews"))

--- a/lib/badfruit/Movies/movie.rb
+++ b/lib/badfruit/Movies/movie.rb
@@ -26,9 +26,14 @@ module BadFruit
       return @badfruit.parse_actors_array(JSON.parse(@badfruit.get_movie_info(@id, "cast")))
     end
 
-    # Returns director, since RottenTomatoes API is broken (abridged_director doesn't show up in search_by_name results for movies.)
+    # Returns directors
     def director
-      return Director.new(JSON.parse(@badfruit.get_movie_info(@id, "details"))["abridged_directors"][0])
+      director_hashes = JSON.parse(@badfruit.get_movie_info(@id, "details"))["abridged_directors"]
+      directors = []
+      if !director_hashes.empty?
+        director_hashes.map{ |h| directors.push(Director.new(h))}  
+      end
+      return directors
     end
 
     #returns an array of Review objects


### PR DESCRIPTION
When using Rotten Tomato's API to search for movies by name, the returned JSON list of films does not contain an "abridged_directors" attribute which is what BadFruit looks for.

However, this attribute does appear when requesting details for a specific movie via ID.

See these two URL's for a demonstration:

http://api.rottentomatoes.com/api/public/v1.0/movies.json?apikey=YOURAPIKEY&q=avengers&page_limit=10&page=1

http://api.rottentomatoes.com/api/public/v1.0/movies/770672122?apikey=YOURAPIKEY

The BadFruit Movie class uses the first link to gather details for the movie. This results in Movie.director being nil. These changes add a new method in the Movie class for getting the director, using a call to the existing Base.get_movie_info method.

This appears to be an old known issue with the API:
http://developer.rottentomatoes.com/forum/read/153926/1#comment-159675
http://developer.rottentomatoes.com/forum/read/157455/1#comment-167903
